### PR TITLE
Add Telegram forum topic support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [Unreleased]
+
+## [0.3.0] - 2026-05-22
+
+- Added support for sending messages to Telegram forum topics with `message_thread_id`
+- Added `config.message_thread_id` as an optional default forum topic for all messages
+- Added per-message `message_thread_id:` overrides, including `message_thread_id: nil`
+  to bypass a configured default topic for one send
+- Preserved `message_thread_id` through async ActiveJob delivery, string-key serialized
+  options, and Markdown-to-HTML-to-plain-text fallback retries
+- Added validation so `message_thread_id` must be a positive integer when present
+- Fixed `parse_mode: nil` to omit the `parse_mode` parameter from Telegram API
+  requests instead of sending `null`
+- Fixed plain-text sends so `parse_mode: nil` does not inherit MarkdownV2 or HTML
+  escaping from configured formatting defaults
+- Fixed HTML sends so they do not inherit MarkdownV2 escaping from configured
+  formatting defaults
+- Fixed MarkdownV2 escaping for underscores inside identifiers such as `is_bot`,
+  `message_thread_id`, and `send_message`
+
 ## [0.2.0] - 2026-01-17
 
 - Added Minitest test suite

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Telegrama.send_message(a_general_message, chat_id: general_chat_id)
 Telegrama.send_message(marketing_message, chat_id: marketing_chat_id)
 ```
 
+You can also send messages to a specific topic inside a forum-enabled Telegram group:
+
+```ruby
+Telegrama.send_message(deploy_message, chat_id: engineering_group_id, message_thread_id: deployments_topic_id)
+```
+
 The goal with this gem is to provide a straightforward, no-frills, minimal API to send Telegram messages reliably for admin purposes, without you having to write your own wrapper over the Telegram API.
 
 ## Quick start
@@ -75,6 +81,7 @@ Then, create an initializer file under `config/initializers/telegrama.rb` and se
 Telegrama.configure do |config|
   config.bot_token = Rails.application.credentials.dig(Rails.env.to_sym, :telegram, :bot_token)
   config.chat_id   = Rails.application.credentials.dig(Rails.env.to_sym, :telegram, :chat_id)
+  config.message_thread_id = nil  # Optional default Telegram forum topic ID
   config.default_parse_mode = 'MarkdownV2'
   
   # Optional prefix/suffix for all messages (useful to identify messages from different apps or environments)
@@ -162,6 +169,22 @@ Both `message_prefix` and `message_suffix` are optional and can be used independ
   ```ruby
   Telegrama.send_message("Hello, alternate group!", chat_id: alternate_chat_id)
   ```
+
+- **`message_thread_id`**
+  *Send to a specific Telegram forum topic inside a group. Telegram's Bot API calls topic IDs `message_thread_id` values.*
+  **Usage Example:**
+  ```ruby
+  Telegrama.send_message("Deploy finished!", chat_id: engineering_group_id, message_thread_id: deployments_topic_id)
+  ```
+
+  You can get this ID from an incoming Telegram update sent inside the topic, or from the `ForumTopic` returned by Telegram's `createForumTopic` API.
+
+  You can also configure a default topic:
+  ```ruby
+  config.message_thread_id = deployments_topic_id
+  ```
+
+  To bypass a configured default topic for one message, pass `message_thread_id: nil`.
 
 - **`parse_mode`**
   *Override the default parse mode (default is `"MarkdownV2"`).*

--- a/lib/telegrama/client.rb
+++ b/lib/telegrama/client.rb
@@ -13,8 +13,19 @@ module Telegrama
 
     # Send a message with built-in error handling and fallbacks
     def send_message(message, options = {})
+      options = normalize_option_keys(options)
+
       # Allow chat ID override; fallback to config default
       chat_id = options.delete(:chat_id) || Telegrama.configuration.chat_id
+
+      # Allow topic/thread override; fallback to config default.
+      # Explicit nil means "send to the chat normally", even when a default topic is configured.
+      message_thread_id = if options.key?(:message_thread_id)
+                            options.delete(:message_thread_id)
+                          else
+                            Telegrama.configuration.message_thread_id
+                          end
+      validate_message_thread_id!(message_thread_id)
 
       # Get client options from config
       client_opts = Telegrama.configuration.client_options || {}
@@ -24,15 +35,11 @@ module Telegrama
       # Use key? to allow explicit nil override (for plain text without formatting)
       parse_mode = options.key?(:parse_mode) ? options[:parse_mode] : Telegrama.configuration.default_parse_mode
 
-      # Allow runtime formatting options, merging with configured defaults
-      formatting_opts = options.delete(:formatting) || {}
-
-      # Add parse mode specific options
-      if parse_mode == 'MarkdownV2'
-        formatting_opts[:escape_markdown] = true unless formatting_opts.key?(:escape_markdown)
-      elsif parse_mode == 'HTML'
-        formatting_opts[:escape_html] = true unless formatting_opts.key?(:escape_html)
-      end
+      # Allow runtime formatting options, merging with configured defaults.
+      # Escape behavior must match the outgoing Telegram parse mode; otherwise
+      # plain-text sends can display MarkdownV2 escape characters literally.
+      formatting_opts = normalize_option_keys(options.delete(:formatting) || {})
+      formatting_opts = formatting_options_for_parse_mode(parse_mode, formatting_opts)
 
       # Format the message text with our formatter
       formatted_message = Formatter.format(message, formatting_opts)
@@ -46,10 +53,11 @@ module Telegrama
         payload = {
           chat_id: chat_id,
           text: formatted_message,
-          parse_mode: parse_mode,
           disable_web_page_preview: options.fetch(:disable_web_page_preview,
                                                  Telegrama.configuration.disable_web_page_preview)
         }
+        payload[:parse_mode] = parse_mode unless parse_mode.nil?
+        payload[:message_thread_id] = message_thread_id unless message_thread_id.nil?
 
         # Additional options such as reply_markup can be added here
         payload.merge!(options.select { |k, _| [:reply_markup, :reply_to_message_id].include?(k) })
@@ -114,6 +122,43 @@ module Telegrama
     end
 
     private
+
+    def normalize_option_keys(options)
+      return {} if options.nil?
+
+      options.to_h.each_with_object({}) do |(key, value), normalized|
+        normalized[key.respond_to?(:to_sym) ? key.to_sym : key] = value
+      end
+    end
+
+    def validate_message_thread_id!(message_thread_id)
+      return if message_thread_id.nil?
+
+      unless message_thread_id.is_a?(Integer) && message_thread_id.positive?
+        raise ArgumentError, "Telegrama send_message option error: message_thread_id must be a positive integer."
+      end
+    end
+
+    def formatting_options_for_parse_mode(parse_mode, formatting_opts)
+      case parse_mode
+      when 'MarkdownV2'
+        {
+          escape_html: false
+        }.merge(formatting_opts).tap do |opts|
+          opts[:escape_markdown] = true unless opts.key?(:escape_markdown)
+        end
+      when 'HTML'
+        {
+          escape_markdown: false
+        }.merge(formatting_opts).tap do |opts|
+          opts[:escape_html] = true unless opts.key?(:escape_html)
+        end
+      when nil
+        formatting_opts.merge(escape_markdown: false, escape_html: false)
+      else
+        formatting_opts
+      end
+    end
 
     def perform_request(payload, options = {})
       uri = URI("https://api.telegram.org/bot#{Telegrama.configuration.bot_token}/sendMessage")

--- a/lib/telegrama/configuration.rb
+++ b/lib/telegrama/configuration.rb
@@ -10,6 +10,10 @@ module Telegrama
     # You can override this on the fly when sending messages.
     attr_accessor :chat_id
 
+    # Default message thread ID for sending messages to a forum topic.
+    # You can override this on the fly when sending messages.
+    attr_accessor :message_thread_id
+
     # Default parse mode for messages (e.g. "MarkdownV2" or "HTML").
     attr_accessor :default_parse_mode
 
@@ -57,6 +61,7 @@ module Telegrama
       # Credentials (must be set via initializer)
       @bot_token = nil
       @chat_id = nil
+      @message_thread_id = nil
 
       # Defaults for message formatting
       @default_parse_mode = 'MarkdownV2'
@@ -90,6 +95,7 @@ module Telegrama
     def validate!
       validate_bot_token!
       validate_default_parse_mode!
+      validate_message_thread_id!
       validate_formatting_options!
       validate_client_options!
       true
@@ -107,6 +113,14 @@ module Telegrama
       allowed_modes = ['MarkdownV2', 'HTML', nil]
       unless allowed_modes.include?(default_parse_mode)
         raise ArgumentError, "Telegrama configuration error: default_parse_mode must be one of #{allowed_modes.inspect}."
+      end
+    end
+
+    def validate_message_thread_id!
+      return if message_thread_id.nil?
+
+      unless message_thread_id.is_a?(Integer) && message_thread_id.positive?
+        raise ArgumentError, "Telegrama configuration error: message_thread_id must be a positive integer."
       end
     end
 

--- a/lib/telegrama/formatter.rb
+++ b/lib/telegrama/formatter.rb
@@ -179,8 +179,12 @@ module Telegrama
           @result += '*'
           advance
         elsif char == '_' && !escaped?
-          enter_state(:italic)
-          @result += '_'
+          if italic_opening_delimiter?
+            enter_state(:italic)
+            @result += '_'
+          else
+            @result += '\\_'
+          end
           advance
         elsif char == '[' && !escaped?
           if looking_at_markdown_link?
@@ -256,8 +260,12 @@ module Telegrama
         char = current_char
 
         if char == '_' && !escaped?
-          exit_state
-          @result += '_'
+          if italic_closing_delimiter?
+            exit_state
+            @result += '_'
+          else
+            @result += '\\_'
+          end
           advance
         elsif char == '\\' && !escaped?
           handle_escape_sequence
@@ -387,6 +395,34 @@ module Telegrama
       # Get the next character
       def next_char
         @chars[@position + 1]
+      end
+
+      # Get the previous character
+      def previous_char
+        @position.positive? ? @chars[@position - 1] : nil
+      end
+
+      # Underscores inside identifiers should render literally, not start italics.
+      def italic_opening_delimiter?
+        following = next_char
+        return false if following.nil? || whitespace?(following)
+
+        !word_char?(previous_char)
+      end
+
+      def italic_closing_delimiter?
+        previous = previous_char
+        return false if previous.nil? || whitespace?(previous)
+
+        !word_char?(next_char)
+      end
+
+      def word_char?(char)
+        !!(char =~ /[[:alnum:]]/)
+      end
+
+      def whitespace?(char)
+        !!(char =~ /\s/)
       end
 
       # Check if next character is one of the given characters

--- a/lib/telegrama/version.rb
+++ b/lib/telegrama/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Telegrama
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/telegrama/client_test.rb
+++ b/test/telegrama/client_test.rb
@@ -117,6 +117,178 @@ class Telegrama::ClientTest < TelegramaTestCase
   end
 
   # ===========================================================================
+  # Forum Topic Tests
+  # ===========================================================================
+
+  def test_send_message_omits_message_thread_id_by_default
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message")
+
+    assert_telegram_request_with_body do |body|
+      !body.key?(:message_thread_id)
+    end
+  end
+
+  def test_send_message_includes_message_thread_id_when_provided
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message", message_thread_id: 42)
+
+    assert_telegram_request_with_body do |body|
+      body[:message_thread_id] == 42
+    end
+  end
+
+  def test_send_message_accepts_message_thread_id_with_string_key
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message", "message_thread_id" => 42)
+
+    assert_telegram_request_with_body do |body|
+      body[:message_thread_id] == 42
+    end
+  end
+
+  def test_send_message_uses_configured_default_message_thread_id
+    Telegrama.configuration.message_thread_id = 101
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message")
+
+    assert_telegram_request_with_body do |body|
+      body[:message_thread_id] == 101
+    end
+  end
+
+  def test_send_message_can_override_configured_message_thread_id
+    Telegrama.configuration.message_thread_id = 101
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message", message_thread_id: 202)
+
+    assert_telegram_request_with_body do |body|
+      body[:message_thread_id] == 202
+    end
+  end
+
+  def test_send_message_can_disable_configured_message_thread_id_with_nil
+    Telegrama.configuration.message_thread_id = 101
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message", message_thread_id: nil)
+
+    assert_telegram_request_with_body do |body|
+      !body.key?(:message_thread_id)
+    end
+  end
+
+  def test_send_message_can_disable_configured_message_thread_id_with_string_key_nil
+    Telegrama.configuration.message_thread_id = 101
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Test message", "message_thread_id" => nil)
+
+    assert_telegram_request_with_body do |body|
+      !body.key?(:message_thread_id)
+    end
+  end
+
+  def test_send_message_preserves_message_thread_id_when_falling_back
+    stub_request(:post, /api\.telegram\.org\/bot.*\/sendMessage/)
+      .to_return(
+        { status: 400, body: { ok: false, description: "Bad Request: can't parse entities" }.to_json },
+        { status: 200, body: successful_telegram_response.to_json }
+      )
+
+    client = Telegrama::Client.new
+    response = client.send_message("*bold* text", message_thread_id: 303)
+
+    assert_equal 200, response.code
+    assert_requested(:post, /api\.telegram\.org\/bot.*\/sendMessage/, times: 2) do |request|
+      JSON.parse(request.body, symbolize_names: true)[:message_thread_id] == 303
+    end
+  end
+
+  def test_send_message_preserves_message_thread_id_through_plain_text_fallback
+    stub_request(:post, /api\.telegram\.org\/bot.*\/sendMessage/)
+      .to_return(
+        { status: 400, body: { ok: false, description: "Bad Request: can't parse entities" }.to_json },
+        { status: 400, body: { ok: false, description: "Bad Request: can't parse entities" }.to_json },
+        { status: 200, body: successful_telegram_response.to_json }
+      )
+
+    client = Telegrama::Client.new
+    response = client.send_message("*bold* text", message_thread_id: 303)
+
+    assert_equal 200, response.code
+
+    requests = WebMock::RequestRegistry.instance.requested_signatures.hash.keys
+    payloads = requests.map { |request| JSON.parse(request.body, symbolize_names: true) }
+
+    assert_equal [303, 303, 303], payloads.map { |payload| payload[:message_thread_id] }
+    refute payloads.last.key?(:parse_mode)
+  end
+
+  def test_send_message_does_not_mutate_options
+    stub_telegram_success
+
+    options = {
+      chat_id: 999,
+      message_thread_id: 42,
+      parse_mode: "HTML",
+      formatting: { escape_html: true },
+      disable_web_page_preview: false
+    }
+    original_options = Marshal.load(Marshal.dump(options))
+
+    client = Telegrama::Client.new
+    client.send_message("Test message", options)
+
+    assert_equal original_options, options
+  end
+
+  def test_send_message_rejects_zero_message_thread_id
+    client = Telegrama::Client.new
+
+    error = assert_raises(ArgumentError) do
+      client.send_message("Test message", message_thread_id: 0)
+    end
+
+    assert_includes error.message, "message_thread_id"
+    assert_no_telegram_request_made
+  end
+
+  def test_send_message_rejects_negative_message_thread_id
+    client = Telegrama::Client.new
+
+    error = assert_raises(ArgumentError) do
+      client.send_message("Test message", message_thread_id: -1)
+    end
+
+    assert_includes error.message, "message_thread_id"
+    assert_no_telegram_request_made
+  end
+
+  def test_send_message_rejects_string_message_thread_id
+    client = Telegrama::Client.new
+
+    error = assert_raises(ArgumentError) do
+      client.send_message("Test message", message_thread_id: "42")
+    end
+
+    assert_includes error.message, "message_thread_id"
+    assert_no_telegram_request_made
+  end
+
+  # ===========================================================================
   # Parse Mode Override Tests
   # ===========================================================================
 
@@ -138,7 +310,66 @@ class Telegrama::ClientTest < TelegramaTestCase
     client.send_message("Test message", parse_mode: nil)
 
     assert_telegram_request_with_body do |body|
-      body[:parse_mode].nil?
+      !body.key?(:parse_mode)
+    end
+  end
+
+  def test_send_message_with_nil_parse_mode_sends_plain_text_without_markdown_escaping
+    Telegrama.configuration.message_prefix = "*~ Test App ~*\n\n"
+    stub_telegram_success
+
+    message = "Timestamp UTC: 2026-05-22T01:30:01Z\n" \
+              "Gem: telegrama 0.3.0\n" \
+              "Bot: @test_bot (id 123, is_bot true)\n" \
+              "Chat ID: -1003778147828\n" \
+              "Topic/message_thread_id: 5019"
+
+    client = Telegrama::Client.new
+    client.send_message(message, parse_mode: nil)
+
+    assert_telegram_request_with_body do |body|
+      !body.key?(:parse_mode) &&
+        body[:text] == "*~ Test App ~*\n\n#{message}"
+    end
+  end
+
+  def test_send_message_omits_parse_mode_when_default_parse_mode_is_nil
+    Telegrama.configuration.default_parse_mode = nil
+    Telegrama.configuration.message_prefix = "*~ Test App ~*\n\n"
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Version 0.3.0 (plain text)")
+
+    assert_telegram_request_with_body do |body|
+      !body.key?(:parse_mode) &&
+        body[:text] == "*~ Test App ~*\n\nVersion 0.3.0 (plain text)"
+    end
+  end
+
+  def test_send_message_with_html_parse_mode_does_not_markdown_escape
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Version 0.3.0 & <ok>", parse_mode: "HTML")
+
+    assert_telegram_request_with_body do |body|
+      body[:parse_mode] == "HTML" &&
+        body[:text] == "Version 0.3.0 &amp; &lt;ok&gt;"
+    end
+  end
+
+  def test_send_message_with_markdownv2_escapes_identifier_underscores
+    stub_telegram_success
+
+    client = Telegrama::Client.new
+    client.send_message("Bot is_bot true; Topic message_thread_id; Method send_message")
+
+    assert_telegram_request_with_body do |body|
+      body[:parse_mode] == "MarkdownV2" &&
+        body[:text].include?("is\\_bot") &&
+        body[:text].include?("message\\_thread\\_id") &&
+        body[:text].include?("send\\_message")
     end
   end
 
@@ -275,6 +506,27 @@ class Telegrama::ClientTest < TelegramaTestCase
 
     assert_equal 200, response.code
     assert_telegram_request_made(times: 3)
+  end
+
+  def test_plain_text_fallback_omits_parse_mode
+    stub_request(:post, /api\.telegram\.org\/bot.*\/sendMessage/)
+      .to_return(
+        { status: 400, body: { ok: false, description: "Bad Request: can't parse entities" }.to_json },
+        { status: 400, body: { ok: false, description: "Bad Request: can't parse entities" }.to_json },
+        { status: 200, body: successful_telegram_response.to_json }
+      )
+
+    client = Telegrama::Client.new
+    response = client.send_message("*bold* text")
+
+    assert_equal 200, response.code
+
+    requests = WebMock::RequestRegistry.instance.requested_signatures.hash.keys
+    payloads = requests.map { |request| JSON.parse(request.body, symbolize_names: true) }
+
+    assert_equal "MarkdownV2", payloads[0][:parse_mode]
+    assert_equal "HTML", payloads[1][:parse_mode]
+    refute payloads[2].key?(:parse_mode)
   end
 
   def test_raises_error_after_all_fallbacks_exhausted

--- a/test/telegrama/configuration_test.rb
+++ b/test/telegrama/configuration_test.rb
@@ -21,6 +21,10 @@ class Telegrama::ConfigurationTest < TelegramaTestCase
     assert_nil @config.chat_id
   end
 
+  def test_defaults_message_thread_id_is_nil
+    assert_nil @config.message_thread_id
+  end
+
   def test_defaults_parse_mode_is_markdownv2
     assert_equal "MarkdownV2", @config.default_parse_mode
   end
@@ -80,6 +84,11 @@ class Telegrama::ConfigurationTest < TelegramaTestCase
   def test_can_set_chat_id_as_negative_for_groups
     @config.chat_id = -1001234567890
     assert_equal(-1001234567890, @config.chat_id)
+  end
+
+  def test_can_set_message_thread_id
+    @config.message_thread_id = 42
+    assert_equal 42, @config.message_thread_id
   end
 
   def test_can_set_parse_mode_to_html
@@ -206,6 +215,57 @@ class Telegrama::ConfigurationTest < TelegramaTestCase
     @config.default_parse_mode = "html"  # Should be "HTML"
     error = assert_raises(ArgumentError) { @config.validate! }
     assert_includes error.message, "default_parse_mode"
+  end
+
+  # ===========================================================================
+  # Validation: message_thread_id Tests
+  # ===========================================================================
+
+  def test_validate_passes_with_nil_message_thread_id
+    @config.bot_token = "token"
+    @config.message_thread_id = nil
+
+    assert @config.validate!
+  end
+
+  def test_validate_passes_with_positive_message_thread_id
+    @config.bot_token = "token"
+    @config.message_thread_id = 42
+
+    assert @config.validate!
+  end
+
+  def test_validate_raises_error_when_message_thread_id_is_zero
+    @config.bot_token = "token"
+    @config.message_thread_id = 0
+
+    error = assert_raises(ArgumentError) { @config.validate! }
+    assert_includes error.message, "message_thread_id"
+    assert_includes error.message, "positive integer"
+  end
+
+  def test_validate_raises_error_when_message_thread_id_is_negative
+    @config.bot_token = "token"
+    @config.message_thread_id = -1
+
+    error = assert_raises(ArgumentError) { @config.validate! }
+    assert_includes error.message, "message_thread_id"
+  end
+
+  def test_validate_raises_error_when_message_thread_id_is_string
+    @config.bot_token = "token"
+    @config.message_thread_id = "42"
+
+    error = assert_raises(ArgumentError) { @config.validate! }
+    assert_includes error.message, "message_thread_id"
+  end
+
+  def test_validate_raises_error_when_message_thread_id_is_float
+    @config.bot_token = "token"
+    @config.message_thread_id = 42.5
+
+    error = assert_raises(ArgumentError) { @config.validate! }
+    assert_includes error.message, "message_thread_id"
   end
 
   # ===========================================================================

--- a/test/telegrama/formatter_test.rb
+++ b/test/telegrama/formatter_test.rb
@@ -149,6 +149,21 @@ class Telegrama::FormatterTest < TelegramaTestCase
     assert_includes result, "\\)"
   end
 
+  def test_escapes_underscores_inside_identifiers
+    text = "Bot is_bot true; topic message_thread_id; method send_message"
+    result = Telegrama::Formatter.format(text)
+
+    assert_includes result, "is\\_bot"
+    assert_includes result, "message\\_thread\\_id"
+    assert_includes result, "send\\_message"
+  end
+
+  def test_preserves_italic_with_identifier_inside
+    result = Telegrama::Formatter.format("This is _message_thread_id_ text")
+
+    assert_includes result, "_message\\_thread\\_id_"
+  end
+
   def test_escapes_brackets_outside_links
     # Note: brackets that don't form a complete link pattern may be treated specially
     # The tokenizer checks for complete [text](url) patterns

--- a/test/telegrama/send_message_job_test.rb
+++ b/test/telegrama/send_message_job_test.rb
@@ -47,11 +47,59 @@ class Telegrama::SendMessageJobTest < TelegramaTestCase
     stub_telegram_success
 
     job = Telegrama::SendMessageJob.new
-    response = job.perform("Test", { chat_id: 999, parse_mode: "HTML" })
+    response = job.perform(
+      "Test",
+      { chat_id: 999, parse_mode: "HTML", message_thread_id: 42 }
+    )
 
     assert_equal 200, response.code
     assert_telegram_request_with_body do |body|
-      body[:chat_id] == 999 && body[:parse_mode] == "HTML"
+      body[:chat_id] == 999 &&
+        body[:parse_mode] == "HTML" &&
+        body[:message_thread_id] == 42
+    end
+  end
+
+  def test_perform_accepts_serialized_string_key_options
+    stub_telegram_success
+
+    job = Telegrama::SendMessageJob.new
+    response = job.perform(
+      "Test",
+      { "chat_id" => 999, "parse_mode" => "HTML", "message_thread_id" => 42 }
+    )
+
+    assert_equal 200, response.code
+    assert_telegram_request_with_body do |body|
+      body[:chat_id] == 999 &&
+        body[:parse_mode] == "HTML" &&
+        body[:message_thread_id] == 42
+    end
+  end
+
+  def test_perform_uses_configured_default_message_thread_id
+    Telegrama.configuration.message_thread_id = 42
+    stub_telegram_success
+
+    job = Telegrama::SendMessageJob.new
+    response = job.perform("Test")
+
+    assert_equal 200, response.code
+    assert_telegram_request_with_body do |body|
+      body[:message_thread_id] == 42
+    end
+  end
+
+  def test_perform_can_bypass_configured_default_message_thread_id
+    Telegrama.configuration.message_thread_id = 42
+    stub_telegram_success
+
+    job = Telegrama::SendMessageJob.new
+    response = job.perform("Test", { "message_thread_id" => nil })
+
+    assert_equal 200, response.code
+    assert_telegram_request_with_body do |body|
+      !body.key?(:message_thread_id)
     end
   end
 
@@ -83,12 +131,13 @@ class Telegrama::SendMessageJobTest < TelegramaTestCase
   end
 
   def test_enqueued_job_has_correct_arguments
-    Telegrama::SendMessageJob.perform_later("Test message", { chat_id: 999 })
+    Telegrama::SendMessageJob.perform_later("Test message", { chat_id: 999, message_thread_id: 42 })
 
     enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.last
     args = enqueued[:args]
     assert_equal "Test message", args[0]
     assert_equal 999, args[1]["chat_id"]
+    assert_equal 42, args[1]["message_thread_id"]
   end
 
   def test_enqueued_job_uses_default_queue
@@ -127,6 +176,38 @@ class Telegrama::SendMessageJobTest < TelegramaTestCase
     enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.last
     assert_equal "notifications", enqueued[:queue]
     assert_equal "Telegrama::SendMessageJob", enqueued[:job].name
+  end
+
+  def test_telegrama_send_message_enqueues_message_thread_id_when_async
+    configure_telegrama(
+      bot_token: "test-token",
+      chat_id: 123,
+      async: true,
+      queue: "notifications"
+    )
+
+    Telegrama.send_message("Async topic message", message_thread_id: 42)
+
+    enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+    assert_equal "Async topic message", enqueued[:args][0]
+    assert_equal 42, enqueued[:args][1]["message_thread_id"]
+  end
+
+  def test_telegrama_send_message_preserves_explicit_nil_message_thread_id_when_async
+    configure_telegrama(
+      bot_token: "test-token",
+      chat_id: 123,
+      message_thread_id: 42,
+      async: true,
+      queue: "notifications"
+    )
+
+    Telegrama.send_message("Async general message", message_thread_id: nil)
+
+    enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs.last
+    assert_equal "Async general message", enqueued[:args][0]
+    assert enqueued[:args][1].key?("message_thread_id")
+    assert_nil enqueued[:args][1]["message_thread_id"]
   end
 
   def test_telegrama_send_message_sync_does_not_enqueue
@@ -190,8 +271,7 @@ class Telegrama::SendMessageJobTest < TelegramaTestCase
     stub_telegram_success
 
     job = Telegrama::SendMessageJob.new
-    # When options is omitted, it defaults to {}
-    response = job.perform("Test")
+    response = job.perform("Test", nil)
 
     assert_equal 200, response.code
   end
@@ -229,6 +309,7 @@ class Telegrama::SendMessageJobTest < TelegramaTestCase
     # Complex options should serialize properly
     options = {
       chat_id: 12345,
+      message_thread_id: 42,
       parse_mode: "HTML",
       formatting: { obfuscate_emails: true }
     }
@@ -240,6 +321,7 @@ class Telegrama::SendMessageJobTest < TelegramaTestCase
 
     assert_equal "Test", args[0]
     assert_equal 12345, args[1]["chat_id"]
+    assert_equal 42, args[1]["message_thread_id"]
     assert_equal "HTML", args[1]["parse_mode"]
   end
 end

--- a/test/telegrama/telegrama_module_test.rb
+++ b/test/telegrama/telegrama_module_test.rb
@@ -73,10 +73,12 @@ class TelegramaModuleTest < TelegramaTestCase
     Telegrama.configure do |config|
       config.bot_token = "new-token"
       config.chat_id = 999
+      config.message_thread_id = 42
     end
 
     assert_equal "new-token", Telegrama.configuration.bot_token
     assert_equal 999, Telegrama.configuration.chat_id
+    assert_equal 42, Telegrama.configuration.message_thread_id
   end
 
   # ===========================================================================
@@ -129,10 +131,12 @@ class TelegramaModuleTest < TelegramaTestCase
       chat_id: 123
     )
 
-    Telegrama.send_message("Test", chat_id: 999, parse_mode: "HTML")
+    Telegrama.send_message("Test", chat_id: 999, parse_mode: "HTML", message_thread_id: 42)
 
     assert_telegram_request_with_body do |body|
-      body[:chat_id] == 999 && body[:parse_mode] == "HTML"
+      body[:chat_id] == 999 &&
+        body[:parse_mode] == "HTML" &&
+        body[:message_thread_id] == 42
     end
   end
 
@@ -148,6 +152,39 @@ class TelegramaModuleTest < TelegramaTestCase
 
     assert_telegram_request_with_body do |body|
       body[:chat_id] == 12345
+    end
+  end
+
+  def test_send_message_uses_default_message_thread_id
+    stub_telegram_success
+
+    Telegrama.configure do |config|
+      config.bot_token = "test-token"
+      config.chat_id = -1001234567890
+      config.message_thread_id = 42
+    end
+
+    Telegrama.send_message("Topic message")
+
+    assert_telegram_request_with_body do |body|
+      body[:chat_id] == -1001234567890 &&
+        body[:message_thread_id] == 42
+    end
+  end
+
+  def test_send_message_can_clear_default_message_thread_id
+    stub_telegram_success
+
+    Telegrama.configure do |config|
+      config.bot_token = "test-token"
+      config.chat_id = -1001234567890
+      config.message_thread_id = 42
+    end
+
+    Telegrama.send_message("General message", message_thread_id: nil)
+
+    assert_telegram_request_with_body do |body|
+      !body.key?(:message_thread_id)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -141,6 +141,7 @@ module TelegramaTestHelpers
   def configure_telegrama(
     bot_token: "test-bot-token",
     chat_id: 123456,
+    message_thread_id: nil,
     parse_mode: "MarkdownV2",
     disable_preview: true,
     prefix: nil,
@@ -155,6 +156,7 @@ module TelegramaTestHelpers
 
     cfg.bot_token = bot_token
     cfg.chat_id = chat_id
+    cfg.message_thread_id = message_thread_id
     cfg.default_parse_mode = parse_mode
     cfg.disable_web_page_preview = disable_preview
     cfg.message_prefix = prefix


### PR DESCRIPTION
# Add Telegram forum topic support

## Summary

This adds first-class support for sending Telegram messages into forum topics inside group chats using Telegram Bot API's `message_thread_id` parameter.

The feature works both as a per-message option and as a configurable default, so applications can route all Telegrama notifications to a specific topic while still overriding or bypassing that topic for individual sends.

This also fixes a live API compatibility issue where `parse_mode: nil` was previously sent to Telegram as JSON `null`. Telegram rejects that payload, so Telegrama now omits `parse_mode` entirely when it is nil.

Additionally, plain-text sends now disable MarkdownV2 and HTML escaping even when those escape options are enabled in the global formatting defaults. This prevents literal backslashes from appearing in messages sent with `parse_mode: nil`.

## Changes

- Add `Telegrama.configuration.message_thread_id`
- Add `message_thread_id:` support to `Telegrama.send_message`
- Include `message_thread_id` in Telegram `sendMessage` payloads when present
- Omit `message_thread_id` when it is nil
- Allow `message_thread_id: nil` to bypass a configured default topic for one message
- Validate configured and per-message `message_thread_id` values as positive integers
- Normalize top-level option keys so ActiveJob/string-key serialized options preserve topic behavior
- Preserve `message_thread_id` through MarkdownV2, HTML, and plain-text fallback retries
- Preserve explicit nil topic overrides through async delivery
- Omit `parse_mode` when it is nil, including plain-text fallback sends
- Disable MarkdownV2 and HTML escaping for plain-text sends
- Prevent HTML sends from inheriting MarkdownV2 escaping from global formatting defaults
- Escape underscores inside MarkdownV2 identifiers such as `is_bot`, `message_thread_id`,
  and `send_message` without breaking intentional `_italic_` formatting
- Document topic usage in the README
- Add the 0.3.0 changelog entry

## Examples

Send one message to a topic:

```ruby
Telegrama.send_message(
  "Deploy finished",
  chat_id: engineering_group_id,
  message_thread_id: deployments_topic_id
)
```

Configure a default topic:

```ruby
Telegrama.configure do |config|
  config.bot_token = Rails.application.credentials.dig(:telegram, :bot_token)
  config.chat_id = Rails.application.credentials.dig(:telegram, :chat_id)
  config.message_thread_id = Rails.application.credentials.dig(:telegram, :message_thread_id)
end
```

Bypass a configured default topic for one message:

```ruby
Telegrama.send_message("General group message", message_thread_id: nil)
```

## Testing

- `bundle exec rake test`
  - 325 tests, 714 assertions, 0 failures
- `bundle exec appraisal rake test`
  - Rails 7.2: 325 tests, 714 assertions, 0 failures
  - Rails 8.0: 325 tests, 714 assertions, 0 failures
  - Rails 8.1: 325 tests, 714 assertions, 0 failures
- `bundle exec rake build`
  - Built `pkg/telegrama-0.3.0.gem`
- `git diff --check`

## Notes

Telegram Bot API does not provide a general "list all topics in this group" endpoint. Topic IDs should be captured from incoming updates sent inside the topic, or from Telegram's forum-topic creation APIs.
